### PR TITLE
Add pytest support, integration tests

### DIFF
--- a/.yourbase.yml
+++ b/.yourbase.yml
@@ -11,14 +11,33 @@ build_targets:
   - name: demo
     commands:
       - python demo.py
-  - name: test
+  - name: lint
     commands:
-      - echo "No tests yet!"
+      - pip install black
+      - black --check .
+  # For integration tests to work locally, you must have access to the
+  # proprietary yourbase-python-engine code, and it must be a sibling directory
+  # to yourbase-python.
+  - name: integration
+    commands:
+      - yb build integration_standard
+      - yb build integration_pytest
+    host_only: true
+  - name: integration_standard
+    commands:
+      - pip install -r tests/integration/requirements.txt
+      - python tests/integration/app.py
+    host_only: true
+  - name: integration_pytest
+    commands:
+      - pip install -r tests/integration/pytest/requirements.txt
+      - pytest -s tests/integration/pytest/app.py
+    host_only: true
 
 ci:
   builds:
     - name: release
       build_target: release
       when: tagged IS true
-    - name: test
-      build_target: test
+    - name: lint
+      build_target: lint

--- a/README.md
+++ b/README.md
@@ -20,14 +20,42 @@ on the YourBase runtime dependency graph.
 Simply run
 ```python
 pip install yourbase
+pip freeze > requirements.txt
 ```
-and decorate your tests with `@accelerate_tests`:
+
+If you use [pytest][pytest] for testing, you're done! YourBase will attach to
+pytest hooks on its own. If you're using a different testing framework, you
+will need to decorate your tests with `@accelerate_tests()`:
 ```python
-@accelerate_tests
+from yourbase import accelerate_tests
+
+# ...
+
+@accelerate_tests()
 class TestApplication:
     # ...
 ```
 
-When you run your tests locally it will have no impact at all, other than
-notifying that it won't accelerate your tests. When you run your tests in the
-YourBase CI, they will be accelerated where possible.
+In both situations, when you run your tests locally it will have no impact at
+all other than printing that it won't accelerate your tests. When you run
+your tests in the YourBase CI, they will be accelerated where possible.
+
+[pytest]: https://pytest.org
+
+## Local development
+This open source package is a lightweight wrapper for your code that plugs it
+into the more complex proprietary systems powering YourBase CI servers. We
+welcome contributions to this wrapper, but at this time we have not built
+shims or mocks to allow it to be tested front to back outside our systems.
+
+### Code style
+We use [Black][black] for code formatting, which is similar in personality to
+`gofmt` -- ruthless consistency, no configuration. Your build **will not pass
+CI** if the Black run doesn't come back clean, so we recommend you have your
+editor automatically run it on save. You can run it manually with
+
+```sh
+black .
+```
+
+[black]: https://pypi.org/project/black/

--- a/demo.py
+++ b/demo.py
@@ -1,5 +1,6 @@
 from yourbase import accelerate_tests
 
+
 @accelerate_tests()
 class TestApplication:
     def __init__(self):
@@ -10,7 +11,6 @@ class TestApplication:
 
     def test_bailout(self, message):
         print("Test message: %s" % (message))
-
 
 
 x = TestApplication()

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,10 @@ setuptools.setup(
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Build Tools",
         "Topic :: Software Development :: Testing",
+        "Framework :: Pytest",
     ],
     python_requires=">=3.6",
+    install_requires=["coverage"],
+    # Register hooks with pytest:
+    entry_points={"pytest11": ["yourbase = yourbase.pytest"]},
 )

--- a/tests/integration/app.py
+++ b/tests/integration/app.py
@@ -1,0 +1,7 @@
+from yourbase import accelerate_tests
+
+
+@accelerate_tests()
+class TestApplication:
+    def test_a_thing(self):
+        print("If you are reading this, this test was not skipped")

--- a/tests/integration/pytest/app.py
+++ b/tests/integration/pytest/app.py
@@ -1,0 +1,5 @@
+# This file is a stub app that uses the pytest component of the Python acceleration.
+
+
+def test_a_thing():
+    print("If you are reading this, this test was not skipped")

--- a/tests/integration/pytest/requirements.txt
+++ b/tests/integration/pytest/requirements.txt
@@ -1,0 +1,8 @@
+# Use this from the top-level yourbase-python directory with
+#   pip install -r tests/integration/requirements.txt
+#   python tests/integration/app.py
+ # This will install your local code for the yourbase-python and
+ # yourbase-python-engine packages.
+
+ ./
+ ../yourbase-python-engine

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,0 +1,9 @@
+# Use this from the top-level yourbase-python directory with
+#   pip install -r tests/integration/pytest/requirements.txt
+#   python tests/integration/pytest/app.py
+ # This will install your local code for the yourbase-python and
+ # yourbase-python-engine packages.
+
+pytest
+ ./
+ ../yourbase-python-engine

--- a/yourbase/__init__.py
+++ b/yourbase/__init__.py
@@ -1,6 +1,7 @@
 import inspect
 import os
 
+
 class YourBaseAccelerationConfig(object):
     """A fake config for use in tests."""
 
@@ -17,47 +18,46 @@ class YourBaseAccelerationConfig(object):
         else:
             return {}
 
+
 CTX = None
 ENABLED = False
 PLUGIN = None
 
-try:
-    import yourbase_plugin
-    if yourbase_plugin.AVAILABLE:
-        try:
-            ENABLED = True
-            from coverage.control import Plugins
-            from coverage import Coverage
-            from coverage.config import CoverageConfig
-            CTX = Coverage()
-            cconf = CoverageConfig()
-            cconf.data_file = None
-            CTX.set_option("run:plugins", ["yourbase_plugin"])
-            print("[YB] Acceleration plugin available!")
-            config = YourBaseAccelerationConfig("yourbase_plugin", {})
-            print("[YB] Loading plugin!")
-            plugins = Plugins.load_plugins(["yourbase_plugin"], config)
-            print("[YB] Starting Python acceleration engine")
-            CTX.start()
-            p = CTX._plugins
-            PLUGIN = p.get("yourbase_plugin.YourBasePlugin")
+import yourbase_plugin
 
-        except:
-            import traceback
-            print("[YB] Problem initializing acceleration subsystem")
-            ENABLED = False
-            traceback.print_exc()
-except ModuleNotFoundError:
-    print("[YB] Acceleration plugin not available.")
-    ENABLED = False
+if yourbase_plugin.AVAILABLE:
+    try:
+        ENABLED = True
+        from coverage.control import Plugins
+        from coverage import Coverage
+        from coverage.config import CoverageConfig
+
+        CTX = Coverage()
+        cconf = CoverageConfig()
+        cconf.data_file = None
+        CTX.set_option("run:plugins", ["yourbase_plugin"])
+        print("[YB] Acceleration plugin available!")
+        config = YourBaseAccelerationConfig("yourbase_plugin", {})
+        print("[YB] Loading plugin!")
+        plugins = Plugins.load_plugins(["yourbase_plugin"], config)
+        print("[YB] Starting Python acceleration engine")
+        CTX.start()
+        p = CTX._plugins
+        PLUGIN = p.get("yourbase_plugin.YourBasePlugin")
+
+    except:
+        import traceback
+
+        print("[YB] Problem initializing acceleration subsystem")
+        ENABLED = False
+        traceback.print_exc()
+
 
 def shutdown_acceleration(self, *args, **kwargs):
     if CTX and PLUGIN:
         print("[YB] Processing acceleration data")
         PLUGIN.dump_graph()
         CTX.stop()
-
-
 
 
 def skip_when_possible(func):
@@ -67,7 +67,7 @@ def skip_when_possible(func):
         else:
             fname = "%s" % (func.__qualname__)
             fpath = os.getcwd() + os.sep + inspect.getfile(func)
-            if (PLUGIN.can_skip(fpath, fname)):
+            if PLUGIN.can_skip(fpath, fname):
                 print("[YB] Skipping %s (@ %s)" % (fname, fpath))
             else:
                 PLUGIN.start_test(fpath, fname)
@@ -82,7 +82,7 @@ def accelerate_tests():
         def __init__(self, cls):
             self.other_class = cls
 
-        def __call__(self,*cls_ars):
+        def __call__(self, *cls_ars):
             other = self.other_class(*cls_ars)
             funcs = inspect.getmembers(self.other_class, predicate=inspect.isfunction)
             for fn in funcs:

--- a/yourbase/pytest.py
+++ b/yourbase/pytest.py
@@ -1,0 +1,28 @@
+# This file sets up YourBase pytest integration.
+#
+# For projects using pytest, the project only needs to add yourbase to its
+# requirements file. This file will be run as an entry point (via setup.py) and
+# will attach to pytest hooks so that tests do not need to be decorated.
+#
+# For projects not using pytest, or when running outside of the YourBase CI,
+# this file does nothing.
+
+import yourbase
+
+
+if yourbase.ENABLED:
+    try:
+        import pytest
+
+        print("[YB] pytest found, attaching")
+        from . import skip_when_possible
+
+        @pytest.hookimpl(tryfirst=True)
+        def pytest_collection_modifyitems(session, config, items):
+            for item in items:
+                item.function.function = skip_when_possible(item.function)
+
+    except ModuleNotFoundError:
+        print(
+            "[YB] YourBase pytest code was initiated, but pytest wasn't found. Is pytest installed oddly?"
+        )


### PR DESCRIPTION
Adds support for pytest. By attaching to hooks they supply, we do not need test decoration -- just `pip install yourbase` and it works :)

Adds integration tests for both the pytest and the non-pytest cases.

Adds Black for strict auto-formatting a la gofmt (I recommend you turn off whitespace changes to review).